### PR TITLE
Drop dmalloc

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -114,6 +114,4 @@ ENABLE_WEBGL := true
 BOARD_SEPOLICY_DIRS += \
 	device/samsung/manta/sepolicy
 
-MALLOC_IMPL := dlmalloc
-
 BOARD_INV_LIBMLLITE_FROM_SOURCE := true


### PR DESCRIPTION
dmalloc is not better in any way compared to the default of jemalloc.
Google even dropped dmalloc completely in N, so even 512mb devices are using jemalloc.
